### PR TITLE
feat(middlewares): add AniList authentication middleware

### DIFF
--- a/src/middlewares/authenticate_anilist.rs
+++ b/src/middlewares/authenticate_anilist.rs
@@ -1,0 +1,72 @@
+// Copyright 2025 - Andriel Ferreira
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! AniList middleware.
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use ferogram::{
+    Context, Injector, Middleware,
+    flow::{self, Flow},
+};
+use grammers_client::{Client, Update};
+
+use crate::{
+    models::User,
+    resources::{AniList, Cache, Database},
+};
+
+/// The middleware to update the Anilist client token.
+#[derive(Clone)]
+pub struct AuthenticateAniList {
+    clients: Cache<i64, Arc<rust_anilist::Client>>,
+}
+
+impl AuthenticateAniList {
+    /// Creates a new instance of the middleware.
+    pub fn new() -> Self {
+        Self {
+            clients: Cache::with_capacity(50),
+        }
+    }
+}
+
+#[async_trait]
+impl Middleware for AuthenticateAniList {
+    async fn handle(&mut self, _: &Client, _: &Update, injector: &mut Injector) -> Flow {
+        let mut ani = (*injector.take::<AniList>().unwrap()).clone();
+
+        let db = injector.get::<Database>().unwrap();
+        let ctx = injector.get::<Context>().unwrap();
+
+        let pool = db.pool();
+        let sender = ctx.sender().expect("no sender found");
+
+        if let Ok(Some(user)) = User::get_by_id(pool, &sender.id()).await {
+            if let Some(client) = self.clients.get(&user.id) {
+                ani.client = client.clone();
+            } else {
+                log::debug!("creating a new Anilist client for user {:?}", user.id);
+
+                let client = Arc::new(if let Some(token) = user.anilist_token {
+                    rust_anilist::Client::with_token(&token).timeout(Duration::from_secs(15))
+                } else {
+                    rust_anilist::Client::with_timeout(Duration::from_secs(15))
+                });
+
+                self.clients.insert(user.id, Arc::clone(&client)).await;
+                ani.client = client;
+            }
+        }
+
+        injector.insert(ani);
+
+        flow::continue_now()
+    }
+}

--- a/src/middlewares/mod.rs
+++ b/src/middlewares/mod.rs
@@ -8,13 +8,17 @@
 
 //! Middlewares.
 
+mod authenticate_anilist;
 mod update_chat_lang;
 
+use authenticate_anilist::AuthenticateAniList;
 use update_chat_lang::UpdateChatLang;
 
 use ferogram::MiddlewareStack;
 
 /// The middlewares setup.
 pub fn setup(stack: MiddlewareStack) -> MiddlewareStack {
-    stack.before(UpdateChatLang)
+    stack
+        .before(UpdateChatLang)
+        .before(AuthenticateAniList::new())
 }

--- a/src/middlewares/update_chat_lang.rs
+++ b/src/middlewares/update_chat_lang.rs
@@ -10,8 +10,8 @@
 
 use async_trait::async_trait;
 use ferogram::{
-    flow::{self, Flow},
     Context, Injector, Middleware,
+    flow::{self, Flow},
 };
 use grammers_client::{Client, Update};
 

--- a/src/plugins/anime.rs
+++ b/src/plugins/anime.rs
@@ -11,14 +11,12 @@
 use std::time::Duration;
 
 use ferogram::{
-    filter, handler,
+    Context, Result, Router, filter, handler,
     utils::{bytes_to_string, split_btns_into_columns},
-    Context, Result, Router,
 };
 use grammers_client::{
-    button, reply_markup,
-    types::{inline, CallbackQuery, InlineQuery},
-    InputMessage,
+    InputMessage, button, reply_markup,
+    types::{CallbackQuery, InlineQuery, inline},
 };
 use maplit::hashmap;
 use rust_anilist::models::{Anime, Format, RelationType};

--- a/src/plugins/auth.rs
+++ b/src/plugins/auth.rs
@@ -146,8 +146,6 @@ async fn auth(message: Message, db: Database, i18n: I18n, config: Config) -> Res
     Ok(())
 }
 
-pub fn authenticate_anilist_account() {}
-
 /// The body of the request to the AniList API.
 #[derive(Serialize)]
 struct Body {

--- a/src/plugins/character.rs
+++ b/src/plugins/character.rs
@@ -10,11 +10,10 @@
 
 use std::time::Duration;
 
-use ferogram::{filter, handler, utils::split_btns_into_columns, Context, Result, Router};
+use ferogram::{Context, Result, Router, filter, handler, utils::split_btns_into_columns};
 use grammers_client::{
-    button, reply_markup,
-    types::{inline, InlineQuery},
-    InputMessage,
+    InputMessage, button, reply_markup,
+    types::{InlineQuery, inline},
 };
 use maplit::hashmap;
 use rust_anilist::models::Character;

--- a/src/plugins/manga.rs
+++ b/src/plugins/manga.rs
@@ -11,14 +11,12 @@
 use std::time::Duration;
 
 use ferogram::{
-    filter, handler,
+    Context, Result, Router, filter, handler,
     utils::{bytes_to_string, split_btns_into_columns},
-    Context, Result, Router,
 };
 use grammers_client::{
-    button, reply_markup,
-    types::{inline, CallbackQuery, InlineQuery},
-    InputMessage,
+    InputMessage, button, reply_markup,
+    types::{CallbackQuery, InlineQuery, inline},
 };
 use maplit::hashmap;
 use rust_anilist::models::{Manga, RelationType};

--- a/src/plugins/user.rs
+++ b/src/plugins/user.rs
@@ -8,11 +8,10 @@
 
 //! The user plugin.
 
-use ferogram::{filter, handler, Context, Result, Router};
+use ferogram::{Context, Result, Router, filter, handler};
 use grammers_client::{
-    button, reply_markup,
-    types::{inline, InlineQuery},
-    InputMessage,
+    InputMessage, button, reply_markup,
+    types::{InlineQuery, inline},
 };
 use maplit::hashmap;
 use rust_anilist::models::User;

--- a/src/resources/anilist.rs
+++ b/src/resources/anilist.rs
@@ -18,10 +18,10 @@ use rust_anilist::{
 use crate::resources::Cache;
 
 /// AniList module.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AniList {
     /// The AniList client.
-    client: Arc<rust_anilist::Client>,
+    pub client: Arc<rust_anilist::Client>,
     /// The cache for anime.
     cache_anime: Cache<i64, Anime>,
     /// The cache for manga.

--- a/src/resources/cache.rs
+++ b/src/resources/cache.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, hash::Hash, sync::Arc};
 use tokio::sync::RwLock;
 
 /// Cache module.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Cache<K, V> {
     /// The underlying map storing the cached values.
     map: Arc<RwLock<HashMap<K, V>>>,


### PR DESCRIPTION
- Introduced `AuthenticateAniList` middleware to manage AniList client tokens.
- Updated `middlewares/mod.rs` to include the new middleware in the stack.
- Refactored imports across plugins for consistency and readability.
- Made `AniList` and `Cache` structs `Debug` for better logging and debugging.
- Exposed `AniList.client` as `pub` for external access.

This enhances the middleware stack with AniList token management and improves code maintainability.